### PR TITLE
Allow other builder configurations to co-exist while using…

### DIFF
--- a/lib/bot_toast.dart
+++ b/lib/bot_toast.dart
@@ -1,6 +1,6 @@
 library bot_toast;
 
 export 'src/basis.dart';
-export 'src/bot_toast_init.dart' show BotToastInit;
+export 'src/bot_toast_init.dart' show BotToastInit, BotToastInitBuilder;
 export 'src/toast.dart';
 export 'src/toast_navigator_observer.dart';

--- a/lib/src/bot_toast_init.dart
+++ b/lib/src/bot_toast_init.dart
@@ -51,3 +51,9 @@ TransitionBuilder BotToastInit() {
     return BotToastManager(key: _key, child: child!);
   };
 }
+
+// ignore: non_constant_identifier_names
+Widget BotToastInitBuilder({required Widget child}) {
+  BotToastWidgetsBindingObserver._singleton;
+  return BotToastManager(key: _key, child: child);
+}


### PR DESCRIPTION
This PR fixes #108.

Let's say. I wanna fix the textScaleFactor across the app. Best way to do this is to copy MediaQuery in MaterialApp
s builder with value textScaleFactor: 1.0. I cannot do that because BotToastInit returns a TransitionBuilder instead of Widget.

#### Example: This code doesn't compile.

```dart
MaterialApp(
  debugShowCheckedModeBanner: false,
  theme: theme,
  navigatorKey: navigatorKey,
  builder: (ctx, child) => MediaQuery(
    data: MediaQuery.of(ctx).copyWith(textScaleFactor: 1.0),
    child: BotToastInit(),
  ),
);
```

#### Expected behavior
It should allow to wrap other widget in the builder of MaterialApp.

#### Example: Expected Behavior

```dart
MaterialApp(
  debugShowCheckedModeBanner: false,
  theme: theme,
  navigatorKey: navigatorKey,
  builder: (ctx, child) => MediaQuery(
    data: MediaQuery.of(ctx).copyWith(textScaleFactor: 1.0),
    child: BotToastInitBuilder(child: child),
  ),
);
```